### PR TITLE
Implement the device creation (with no customer association) feature

### DIFF
--- a/src/main/java/io/landolfi/device/DeviceDto.java
+++ b/src/main/java/io/landolfi/device/DeviceDto.java
@@ -1,0 +1,7 @@
+package io.landolfi.device;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+public record DeviceDto(@NotBlank String uuid, @NotNull DeviceState state) {
+}

--- a/src/main/java/io/landolfi/device/DeviceResource.java
+++ b/src/main/java/io/landolfi/device/DeviceResource.java
@@ -1,0 +1,25 @@
+package io.landolfi.device;
+
+import io.landolfi.device.repository.DeviceRepository;
+
+import javax.validation.Valid;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import java.net.URI;
+
+@Path("/devices")
+public class DeviceResource {
+
+    private final DeviceRepository<DeviceDto> deviceRepository;
+
+    public DeviceResource(DeviceRepository<DeviceDto> deviceRepository) {
+        this.deviceRepository = deviceRepository;
+    }
+
+    @POST
+    public Response createDevice(@Valid DeviceDto received) {
+        deviceRepository.save(received);
+        return Response.created(URI.create("/devices/" + received.uuid())).entity(received).build();
+    }
+}

--- a/src/main/java/io/landolfi/device/DeviceState.java
+++ b/src/main/java/io/landolfi/device/DeviceState.java
@@ -1,0 +1,18 @@
+package io.landolfi.device;
+
+public enum DeviceState {
+    ACTIVE("ACTIVE"),
+    INACTIVE("INACTIVE"),
+    LOST("LOST");
+
+    public final String state;
+
+    DeviceState(String state) {
+        this.state = state;
+    }
+
+    @Override
+    public String toString() {
+        return state;
+    }
+}

--- a/src/main/java/io/landolfi/device/repository/DeviceRepository.java
+++ b/src/main/java/io/landolfi/device/repository/DeviceRepository.java
@@ -1,0 +1,7 @@
+package io.landolfi.device.repository;
+
+public interface DeviceRepository<T> {
+    T save(T device);
+
+    void deleteAll();
+}

--- a/src/main/java/io/landolfi/device/repository/InMemoryDeviceRepository.java
+++ b/src/main/java/io/landolfi/device/repository/InMemoryDeviceRepository.java
@@ -1,0 +1,27 @@
+package io.landolfi.device.repository;
+
+import io.landolfi.device.DeviceDto;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@ApplicationScoped
+public class InMemoryDeviceRepository implements DeviceRepository<DeviceDto> {
+
+
+    private final Map<UUID, DeviceDto> devices = Collections.synchronizedMap(new HashMap<>());
+
+    @Override
+    public DeviceDto save(DeviceDto device) {
+        devices.put(UUID.fromString(device.uuid()), device);
+        return device;
+    }
+
+    @Override
+    public void deleteAll() {
+        devices.clear();
+    }
+}

--- a/src/test/java/io/landolfi/integration/DeviceResourceTest.java
+++ b/src/test/java/io/landolfi/integration/DeviceResourceTest.java
@@ -1,0 +1,53 @@
+package io.landolfi.integration;
+
+import io.landolfi.device.DeviceDto;
+import io.landolfi.device.DeviceResource;
+import io.landolfi.device.DeviceState;
+import io.landolfi.device.repository.InMemoryDeviceRepository;
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import java.net.URI;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+@TestHTTPEndpoint(DeviceResource.class)
+class DeviceResourceTest {
+    @TestHTTPEndpoint(DeviceResource.class)
+    @TestHTTPResource
+    URI devicesUri;
+
+    @Inject
+    InMemoryDeviceRepository deviceRepository;
+
+    @BeforeEach
+    void beforeEach() {
+        deviceRepository.deleteAll();
+    }
+
+    @Test
+    void shouldCreateTheGivenDeviceSuccessfully_WhenPostingToTheEndpoint(){
+        String deviceToCreateUuid = "7b787913-bda9-41dc-8966-458fe1e3c5ce";
+        DeviceDto givenDevice = new DeviceDto(deviceToCreateUuid, DeviceState.ACTIVE);
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(givenDevice)
+        .when()
+            .post()
+        .then()
+            .statusCode(201)
+            .header(HttpHeaders.LOCATION, devicesUri.resolve(devicesUri.getPath() + "/" + deviceToCreateUuid).toString())
+            .body("uuid", equalTo(deviceToCreateUuid))
+            .body("state", equalTo(DeviceState.ACTIVE.toString()));
+    }
+
+}


### PR DESCRIPTION
Now we are able to create a new `Device` resource through a `POST` operation. Note that, for now, a device is NOT associated to any customer when it's being created