### PR TITLE
Implement retrieval of all devices (with no customer association) feature

### DIFF
--- a/src/main/java/io/landolfi/customer/repository/InMemoryCustomerRepository.java
+++ b/src/main/java/io/landolfi/customer/repository/InMemoryCustomerRepository.java
@@ -13,7 +13,7 @@ import java.util.*;
  */
 @ApplicationScoped
 public class InMemoryCustomerRepository implements CustomerRepository<CustomerDto> {
-    private final Map<UUID, CustomerDto> customers = Collections.synchronizedMap(new HashMap<>());
+    private final Map<UUID, CustomerDto> customers = Collections.synchronizedMap(new LinkedHashMap<>());
 
     @Override
     public List<CustomerDto> findAll() {

--- a/src/main/java/io/landolfi/device/DeviceResource.java
+++ b/src/main/java/io/landolfi/device/DeviceResource.java
@@ -3,6 +3,7 @@ package io.landolfi.device;
 import io.landolfi.device.repository.DeviceRepository;
 
 import javax.validation.Valid;
+import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
@@ -21,5 +22,10 @@ public class DeviceResource {
     public Response createDevice(@Valid DeviceDto received) {
         deviceRepository.save(received);
         return Response.created(URI.create("/devices/" + received.uuid())).entity(received).build();
+    }
+
+    @GET
+    public DevicesDto retrieveAllDevices() {
+        return new DevicesDto(deviceRepository.findAll());
     }
 }

--- a/src/main/java/io/landolfi/device/DevicesDto.java
+++ b/src/main/java/io/landolfi/device/DevicesDto.java
@@ -1,0 +1,6 @@
+package io.landolfi.device;
+
+import java.util.List;
+
+public record DevicesDto(List<DeviceDto> devices) {
+}

--- a/src/main/java/io/landolfi/device/repository/DeviceRepository.java
+++ b/src/main/java/io/landolfi/device/repository/DeviceRepository.java
@@ -1,7 +1,11 @@
 package io.landolfi.device.repository;
 
+import java.util.List;
+
 public interface DeviceRepository<T> {
     T save(T device);
 
     void deleteAll();
+
+    List<T> findAll();
 }

--- a/src/main/java/io/landolfi/device/repository/InMemoryDeviceRepository.java
+++ b/src/main/java/io/landolfi/device/repository/InMemoryDeviceRepository.java
@@ -3,10 +3,7 @@ package io.landolfi.device.repository;
 import io.landolfi.device.DeviceDto;
 
 import javax.enterprise.context.ApplicationScoped;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 @ApplicationScoped
 public class InMemoryDeviceRepository implements DeviceRepository<DeviceDto> {
@@ -23,5 +20,10 @@ public class InMemoryDeviceRepository implements DeviceRepository<DeviceDto> {
     @Override
     public void deleteAll() {
         devices.clear();
+    }
+
+    @Override
+    public List<DeviceDto> findAll() {
+        return devices.values().stream().toList();
     }
 }

--- a/src/main/java/io/landolfi/device/repository/InMemoryDeviceRepository.java
+++ b/src/main/java/io/landolfi/device/repository/InMemoryDeviceRepository.java
@@ -9,7 +9,7 @@ import java.util.*;
 public class InMemoryDeviceRepository implements DeviceRepository<DeviceDto> {
 
 
-    private final Map<UUID, DeviceDto> devices = Collections.synchronizedMap(new HashMap<>());
+    private final Map<UUID, DeviceDto> devices = Collections.synchronizedMap(new LinkedHashMap<>());
 
     @Override
     public DeviceDto save(DeviceDto device) {

--- a/src/test/java/io/landolfi/integration/DeviceResourceTest.java
+++ b/src/test/java/io/landolfi/integration/DeviceResourceTest.java
@@ -76,4 +76,41 @@ class DeviceResourceTest {
             .body("devices[0].state", equalTo(DeviceState.INACTIVE.toString()));
     }
 
+    @Test
+    void shouldRetrieveAllDevicesSuccessfully_WhenRequestingAllDevicesAndMultipleDevicesHaveBeenPostedToTheEndpoint() {
+        // Arrange
+        String firstDeviceUuid = "7b787913-bda9-41dc-8966-458fe1e3c5ce";
+        DeviceDto firstDevice = new DeviceDto(firstDeviceUuid, DeviceState.LOST);
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(firstDevice)
+        .when()
+            .post()
+        .then()
+            .statusCode(201);
+
+        String secondDeviceUuid = "8e24a4fd-9cfb-44ef-a94c-2a1692673665";
+        DeviceDto secondDevice = new DeviceDto(secondDeviceUuid, DeviceState.INACTIVE);
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(secondDevice)
+        .when()
+            .post()
+        .then()
+            .statusCode(201);
+
+        // Act and Assert
+        when()
+            .get()
+        .then()
+            .statusCode(200)
+            .body("devices", hasSize(2))
+            .body("devices[0].uuid", equalTo(firstDeviceUuid))
+            .body("devices[0].state", equalTo(DeviceState.LOST.toString()))
+            .body("devices[1].uuid", equalTo(secondDeviceUuid))
+            .body("devices[1].state", equalTo(DeviceState.INACTIVE.toString()));
+    }
+
 }

--- a/src/test/java/io/landolfi/integration/DeviceResourceTest.java
+++ b/src/test/java/io/landolfi/integration/DeviceResourceTest.java
@@ -16,7 +16,9 @@ import javax.ws.rs.core.MediaType;
 import java.net.URI;
 
 import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 
 @QuarkusTest
 @TestHTTPEndpoint(DeviceResource.class)
@@ -48,6 +50,30 @@ class DeviceResourceTest {
             .header(HttpHeaders.LOCATION, devicesUri.resolve(devicesUri.getPath() + "/" + deviceToCreateUuid).toString())
             .body("uuid", equalTo(deviceToCreateUuid))
             .body("state", equalTo(DeviceState.ACTIVE.toString()));
+    }
+
+    @Test
+    void shouldRetrieveOneDeviceSuccessfully_WhenRequestingAllDevicesAndOneDeviceHasBeenPostedToTheEndpoint(){
+        // Arrange
+        String deviceToRetrieveUuid = "7b787913-bda9-41dc-8966-458fe1e3c5ce";
+        DeviceDto givenDevice = new DeviceDto(deviceToRetrieveUuid, DeviceState.INACTIVE);
+
+       given()
+           .contentType(MediaType.APPLICATION_JSON)
+           .body(givenDevice)
+       .when()
+           .post()
+       .then()
+           .statusCode(201);
+
+        // Act and Assert
+        when()
+            .get()
+        .then()
+            .statusCode(200)
+            .body("devices", hasSize(1))
+            .body("devices[0].uuid", equalTo(deviceToRetrieveUuid))
+            .body("devices[0].state", equalTo(DeviceState.INACTIVE.toString()));
     }
 
 }


### PR DESCRIPTION
- Now we are able to retrieve all `Device` resource through a `GET` operation
- fix a bug in the implementation of the in-memory repositories