### PR TITLE
Implement aggregate retrieval of a customer's device(s)

### DIFF
--- a/src/main/java/io/landolfi/customer/CustomerResource.java
+++ b/src/main/java/io/landolfi/customer/CustomerResource.java
@@ -126,4 +126,20 @@ public class CustomerResource {
 
         return Response.ok().entity(DevicesDto.withOneDevice(optAssociatedDevice.get())).build();
     }
+
+    @GET
+    @Path("/{customerId}/devices")
+    public Response retrieveAllDevicesAssociatedToACustomer(@PathParam("customerId") String customerId) {
+        Optional<CustomerDto> optGivenCustomer = customerRepository.findByUuid(customerId);
+        if (optGivenCustomer.isEmpty()) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+
+        CustomerDto givenCustomer = optGivenCustomer.get();
+        if (givenCustomer.devices().isEmpty()) {
+            return Response.ok().entity(DevicesDto.empty()).build();
+        }
+
+        return Response.ok().entity(new DevicesDto(givenCustomer.devices())).build();
+    }
 }

--- a/src/main/java/io/landolfi/customer/CustomerResource.java
+++ b/src/main/java/io/landolfi/customer/CustomerResource.java
@@ -2,6 +2,7 @@ package io.landolfi.customer;
 
 import io.landolfi.customer.repository.CustomerRepository;
 import io.landolfi.device.DeviceDto;
+import io.landolfi.device.DevicesDto;
 import io.landolfi.device.repository.DeviceRepository;
 import io.landolfi.generator.UniqueIdGenerator;
 import io.landolfi.util.rest.ErrorDto;
@@ -105,5 +106,24 @@ public class CustomerResource {
         customerRepository.save(withTheCreatedDevice);
 
         return Response.created(URI.create("/devices/" + received.uuid())).entity(received).build();
+    }
+
+    @GET
+    @Path("/{customerId}/devices/{deviceId}")
+    public Response retrieveADeviceAssociatedToACustomer(@PathParam("customerId") String customerId, @PathParam(
+            "deviceId") String deviceId) {
+        Optional<CustomerDto> optGivenCustomer = customerRepository.findByUuid(customerId);
+        if (optGivenCustomer.isEmpty()) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+
+        CustomerDto givenCustomer = optGivenCustomer.get();
+        Optional<DeviceDto> optAssociatedDevice =
+                givenCustomer.devices().stream().filter(device -> device.uuid().equals(deviceId)).findFirst();
+        if (optAssociatedDevice.isEmpty()) {
+            return Response.ok().entity(DevicesDto.empty()).build();
+        }
+
+        return Response.ok().entity(DevicesDto.withOneDevice(optAssociatedDevice.get())).build();
     }
 }

--- a/src/main/java/io/landolfi/device/DeviceResource.java
+++ b/src/main/java/io/landolfi/device/DeviceResource.java
@@ -7,7 +7,6 @@ import javax.validation.Valid;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 import java.net.URI;
-import java.util.Collections;
 import java.util.Optional;
 
 @Path("/devices")
@@ -35,7 +34,7 @@ public class DeviceResource {
     public DevicesDto retrieveDeviceById(@PathParam("deviceId") String deviceId) {
        Optional<DeviceDto> toReturn = deviceRepository.findByUuid(deviceId);
        if (toReturn.isEmpty()) {
-           return new DevicesDto(Collections.emptyList());
+           return DevicesDto.empty();
        }
        return DevicesDto.withOneDevice(toReturn.get());
     }

--- a/src/main/java/io/landolfi/device/DevicesDto.java
+++ b/src/main/java/io/landolfi/device/DevicesDto.java
@@ -8,4 +8,8 @@ public record DevicesDto(@Valid List<DeviceDto> devices) {
     public static DevicesDto withOneDevice(DeviceDto device) {
         return new DevicesDto(Collections.singletonList(device));
     }
+
+    public static DevicesDto empty() {
+        return new DevicesDto(Collections.emptyList());
+    }
 }

--- a/src/test/java/io/landolfi/integration/CustomerResourceTest.java
+++ b/src/test/java/io/landolfi/integration/CustomerResourceTest.java
@@ -472,4 +472,28 @@ class CustomerResourceTest {
             .body("customers[0].devices[1].uuid", equalTo("3813f9ce-b06c-4f0c-8514-b146df7bcb53"))
             .body("customers[0].devices[1].state", equalTo(DeviceState.INACTIVE.toString()));
     }
+
+    @Test
+    void shouldRetrieveTheRequestedDeviceForTheGivenCustomerSuccessfully_WhenThatDeviceIsRequestedByUuidThroughTheSubresourceEndpoint() {
+        // Arrange
+        String deviceToRetrieveUuid = "7b787913-bda9-41dc-8966-458fe1e3c5ce";
+        DeviceDto givenDevice = new DeviceDto(deviceToRetrieveUuid, DeviceState.ACTIVE);
+        deviceRepository.save(givenDevice);
+
+        AddressDto givenAddress = new AddressDto("Via fasulla 10", "Padova", "Padova", "Veneto");
+        String givenCustomerUuid = "c8a255af-208d-4a98-bbff-8244a7a28609";
+        CustomerDto givenCustomer = new CustomerDto(UUID.fromString(givenCustomerUuid), "Nicola", "Landolfi",
+                "XFFTPK41D24B969W",
+                givenAddress, List.of(givenDevice));
+        customerRepository.save(givenCustomer);
+
+        // Act and Assert
+        when()
+            .get("/" + givenCustomerUuid + "/devices/" + deviceToRetrieveUuid)
+        .then()
+            .statusCode(200)
+            .body("devices", hasSize(1))
+            .body("devices[0].uuid", equalTo(deviceToRetrieveUuid))
+            .body("devices[0].state", equalTo(DeviceState.ACTIVE.toString()));
+    }
 }

--- a/src/test/java/io/landolfi/integration/CustomerResourceTest.java
+++ b/src/test/java/io/landolfi/integration/CustomerResourceTest.java
@@ -496,4 +496,33 @@ class CustomerResourceTest {
             .body("devices[0].uuid", equalTo(deviceToRetrieveUuid))
             .body("devices[0].state", equalTo(DeviceState.ACTIVE.toString()));
     }
+
+    @Test
+    void shouldSuccessfullyRetrieveAllDevicesForTheGivenCustomer_WhenRequestingAllDevicesThroughTheSubresourceEndpoint() {
+        // Arrange
+        String firstDeviceUuid = "7b787913-bda9-41dc-8966-458fe1e3c5ce";
+        String secondDeviceUuid = "3813f9ce-b06c-4f0c-8514-b146df7bcb53";
+        DeviceDto firstAssociatedDevice = new DeviceDto(firstDeviceUuid, DeviceState.ACTIVE);
+        DeviceDto secondAssociatedDevice = new DeviceDto(secondDeviceUuid, DeviceState.INACTIVE);
+        deviceRepository.save(firstAssociatedDevice);
+        deviceRepository.save(secondAssociatedDevice);
+
+        AddressDto givenAddress = new AddressDto("Via fasulla 10", "Padova", "Padova", "Veneto");
+        String givenCustomerUuid = "c8a255af-208d-4a98-bbff-8244a7a28609";
+        CustomerDto givenCustomer = new CustomerDto(UUID.fromString(givenCustomerUuid), "Nicola", "Landolfi",
+                "XFFTPK41D24B969W",
+                givenAddress, List.of(firstAssociatedDevice, secondAssociatedDevice));
+        customerRepository.save(givenCustomer);
+
+        // Act and Assert
+        when()
+            .get("/" + givenCustomerUuid + "/devices")
+        .then()
+            .statusCode(200)
+            .body("devices", hasSize(2))
+            .body("devices[0].uuid", equalTo(firstDeviceUuid))
+            .body("devices[0].state", equalTo(DeviceState.ACTIVE.toString()))
+            .body("devices[1].uuid", equalTo(secondDeviceUuid))
+            .body("devices[1].state", equalTo(DeviceState.INACTIVE.toString()));
+    }
 }


### PR DESCRIPTION
Now we are able to:

1. retrieve a `Customer` resource along with the `Device` resource(s) associated to the customer itself;
2. retrieve a specific `Device` resource for a specific customer through the `/devices` subresource endpoint
3. retrieve all `Device` resources for a specific customer through the `/devices` subresource endpoint